### PR TITLE
[BREAKING CHANGE] Simplify API

### DIFF
--- a/README
+++ b/README
@@ -19,8 +19,8 @@ See documentation for example.
 
 DOCUMENTATION
 
-See http://go.pkgdoc.org/github.com/dchest/wots
+See https://godoc.org/github.com/dchest/wots
 
 LICENSE
-	
+
 BSD-like, see LICENSE file.

--- a/example_test.go
+++ b/example_test.go
@@ -8,29 +8,30 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+
 	"github.com/dchest/wots"
 )
 
 func Example() {
 	// Define scheme using SHA-256. There's no need to always
 	// create this scheme, it can be a global variable.
-	var wotssha256 = wots.NewScheme(sha256.New)
+	var wotssha256 = wots.NewScheme(sha256.New, rand.Reader)
 
 	// Generating key pair.
-	key, err := wotssha256.GenerateKey(rand.Reader)
+	privateKey, publicKey, err := wotssha256.GenerateKeyPair()
 	if err != nil {
 		panic("key generation failed")
 	}
 
-	// Messages will be verified against this public key.
-	publicKey := key.PublicKey // => 32-byte public key
-
 	// Signing.
 	message := []byte("Hello world!")
-	signature := wotssha256.Sign(key, message) // => 1120-byte signature
+	signature, err := wotssha256.Sign(privateKey, message) // => 1120-byte signature
+	if err != nil {
+		panic("signature calculation failed")
+	}
 
-	// After signing once, key can't be used to sign more messages.
-	// For safety, private key bytes are destroyed, only key.PublicKey left.
+	// After signing once, private key must not be used to sign more messages!
+	// This is a one-time signature scheme.
 
 	// Verifying.
 	if wotssha256.Verify(publicKey, message, signature) {


### PR DESCRIPTION
* NewScheme now takes a random reader for key generation and message
  randomization.
* PrivateKey and PublicKey are separated into different types
  and are just []byte.
* Message randomization value is now generated during signing.

Previously it was impossible to save private key because message
randomization value was generated during key pair generation and was not
exported.